### PR TITLE
Assignment 3

### DIFF
--- a/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/domain/FloatingBreak.java
+++ b/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/domain/FloatingBreak.java
@@ -1,0 +1,30 @@
+package org.acme.vehiclerouting.domain;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+public class FloatingBreak {
+    public FloatingBreak(LocalDateTime triggerTime, Duration duration) {
+        this.triggerTime = triggerTime;
+        this.duration = duration;
+    }
+
+    private LocalDateTime triggerTime;
+    private Duration duration;
+
+    public java.time.Duration getDuration() {
+        return duration;
+    }
+
+    public void setDuration(java.time.Duration duration) {
+        this.duration = duration;
+    }
+
+    public LocalDateTime getTriggerTime() {
+        return triggerTime;
+    }
+
+    public void setTriggerTime(LocalDateTime triggerTime) {
+        this.triggerTime = triggerTime;
+    }
+}

--- a/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/domain/Vehicle.java
+++ b/java/vehicle-routing/src/main/java/org/acme/vehiclerouting/domain/Vehicle.java
@@ -25,6 +25,9 @@ public class Vehicle {
     private LocalDateTime departureTime;
     private LocalDateTime maxLastVisitDepartureTime;
 
+    private FloatingBreak floatingBreak;
+    private LocalDateTime floatingBreakActiveAt;
+
     @JsonIdentityReference(alwaysAsId = true)
     @PlanningListVariable
     private List<Visit> visits;
@@ -83,6 +86,22 @@ public class Vehicle {
 
     public void setMaxLastVisitDepartureTime(LocalDateTime maxLastVisitDepartureTime) {
         this.maxLastVisitDepartureTime = maxLastVisitDepartureTime;
+    }
+
+    public FloatingBreak getFloatingBreak() {
+        return floatingBreak;
+    }
+
+    public void setFloatingBreak(FloatingBreak floatingBreak) {
+        this.floatingBreak = floatingBreak;
+    }
+
+    public LocalDateTime getFloatingBreakActiveAt() {
+        return floatingBreakActiveAt;
+    }
+
+    public void setFloatingBreakActiveAt(LocalDateTime floatingBreakActiveAt) {
+        this.floatingBreakActiveAt = floatingBreakActiveAt;
     }
 
     // ************************************************************************
@@ -149,4 +168,5 @@ public class Vehicle {
     public String toString() {
         return id;
     }
+
 }

--- a/java/vehicle-routing/src/test/java/org/acme/vehiclerouting/rest/VehicleRoutingEnvironmentTest.java
+++ b/java/vehicle-routing/src/test/java/org/acme/vehiclerouting/rest/VehicleRoutingEnvironmentTest.java
@@ -12,6 +12,7 @@ import ai.timefold.solver.core.api.solver.SolverFactory;
 import ai.timefold.solver.core.config.solver.EnvironmentMode;
 import ai.timefold.solver.core.config.solver.SolverConfig;
 
+import org.acme.vehiclerouting.domain.FloatingBreak;
 import org.acme.vehiclerouting.domain.VehicleRoutePlan;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -43,6 +44,9 @@ class VehicleRoutingEnvironmentTest {
                 .statusCode(200)
                 .extract()
                 .as(VehicleRoutePlan.class);
+        var firstVehicle = problem.getVehicles().get(0);
+        // require a floating break after 2 hours for 30 minutes
+        firstVehicle.setFloatingBreak(new FloatingBreak(firstVehicle.getDepartureTime().plusHours(2), Duration.ofMinutes(30)));
 
         // Update the environment
         SolverConfig updatedConfig = solverConfig.copyConfig();
@@ -55,5 +59,6 @@ class VehicleRoutingEnvironmentTest {
         Solver<VehicleRoutePlan> solver = solverFactory.buildSolver();
         VehicleRoutePlan solution = solver.solve(problem);
         assertThat(solution.getScore()).isNotNull();
+        assertThat(solution.getVehicles().get(0).getFloatingBreakActiveAt() != null).isTrue();
     }
 }

--- a/java/vehicle-routing/src/test/java/org/acme/vehiclerouting/solver/VehicleRoutingConstraintProviderTest.java
+++ b/java/vehicle-routing/src/test/java/org/acme/vehiclerouting/solver/VehicleRoutingConstraintProviderTest.java
@@ -141,29 +141,6 @@ class VehicleRoutingConstraintProviderTest {
                 .penalizesBy(Duration.between(tomorrow_08_00, visit2.getArrivalTime().plusMinutes(visit2.getServiceDuration().toMinutes())).toMinutes());
     }
 
-    @Test
-    void arrivalTimeUpdatingVariableListener() {
-        LocalDateTime tomorrow_07_00 = LocalDateTime.of(TOMORROW, LocalTime.of(7, 0));
-        LocalDateTime tomorrow_08_00 = LocalDateTime.of(TOMORROW, LocalTime.of(8, 0));
-        LocalDateTime tomorrow_08_40 = LocalDateTime.of(TOMORROW, LocalTime.of(8, 40));
-        LocalDateTime tomorrow_09_00 = LocalDateTime.of(TOMORROW, LocalTime.of(9, 0));
-        LocalDateTime tomorrow_10_30 = LocalDateTime.of(TOMORROW, LocalTime.of(10, 30));
-        LocalDateTime tomorrow_18_00 = LocalDateTime.of(TOMORROW, LocalTime.of(18, 0));
-
-        Visit visit1 = new Visit("2", "John", LOCATION_2, 80, tomorrow_08_00, tomorrow_18_00, Duration.ofHours(1L));
-        visit1.setArrivalTime(tomorrow_08_40);
-        Visit visit2 = new Visit("3", "Paul", LOCATION_3, 40, tomorrow_08_00, tomorrow_09_00, Duration.ofHours(1L));
-        visit2.setArrivalTime(tomorrow_10_30);
-        Vehicle vehicleA = new Vehicle("1", 100, LOCATION_1, tomorrow_07_00, tomorrow_08_00);
-        vehicleA.setFloatingBreak(new FloatingBreak(tomorrow_08_00, Duration.ofMinutes(30L)));
-
-        connect(vehicleA, visit1, visit2);
-
-        constraintVerifier.verifyThat(VehicleRoutingConstraintProvider::maxLastVisitDepartureTime)
-                .given(vehicleA, visit1, visit2)
-                .penalizesBy(240);
-    }
-
     static void connect(Vehicle vehicle, Visit... visits) {
         vehicle.setVisits(Arrays.asList(visits));
         for (int i = 0; i < visits.length; i++) {


### PR DESCRIPTION
## Description of the change

This PR adds support for Floating Breaks.

## Issues

It currently throws an error suggesting that the solution score differs from the score that is computed when executing a `Move` and then undoing it.

```
java.lang.IllegalStateException: UndoMove corruption (-7hard):
   the beforeMoveScore (-27init/0hard/-6191soft) is not the undoScore (-27init/-7hard/-6191soft),
   which is the uncorruptedScore (-27init/-7hard/-6191soft) of the workingSolution.

Corruption diagnosis:


1) Enable EnvironmentMode TRACKED_FULL_ASSERT (if you haven't already)
   to fail-faster in case of a score corruption or variable listener corruption.
   Let the solver run until it reaches the same point in its lifecycle (Phase index (0), step index (50), move index (0).),
   even though it may take a very long time.
   If the solver throws an exception before reaching that point,
   there may be yet another problem that needs to be fixed.

2) If you use custom moves, check the Move.createUndoMove(...) method of the custom move class (ListAssignMove).
   The move (51 {null -> 1[0]}) might have a corrupted undoMove (Undo(51 {null -> 1[0]})).

3) If you use custom VariableListeners,
   check them for shadow variables that are used by score constraints
   that could cause the scoreDifference (-7hard).

	at ai.timefold.solver.core.impl.score.director.AbstractScoreDirector.assertExpectedUndoMoveScore(AbstractScoreDirector.java:704)
	at ai.timefold.solver.core.impl.constructionheuristic.decider.ConstructionHeuristicDecider.doMove(ConstructionHeuristicDecider.java:138)
	at ai.timefold.solver.core.impl.constructionheuristic.decider.ConstructionHeuristicDecider.decideNextStep(ConstructionHeuristicDecider.java:107)
	at ai.timefold.solver.core.impl.constructionheuristic.DefaultConstructionHeuristicPhase.solve(DefaultConstructionHeuristicPhase.java:62)
	at ai.timefold.solver.core.impl.solver.AbstractSolver.runPhases(AbstractSolver.java:82)
	at ai.timefold.solver.core.impl.solver.DefaultSolver.solve(DefaultSolver.java:200)
	at org.acme.vehiclerouting.rest.VehicleRoutingEnvironmentTest.solve(VehicleRoutingEnvironmentTest.java:60)
	at org.acme.vehiclerouting.rest.VehicleRoutingEnvironmentTest.solveFullAssert(VehicleRoutingEnvironmentTest.java:31)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at io.quarkus.test.junit.QuarkusTestExtension.runExtensionMethod(QuarkusTestExtension.java:1017)
	at io.quarkus.test.junit.QuarkusTestExtension.interceptTestMethod(QuarkusTestExtension.java:831)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)

Jul 04, 2024 4:20:50 PM io.quarkus.bootstrap.runner.Timing printStopTime
INFO: vehicle-routing stopped in 0.070s
```